### PR TITLE
Add mocked duplex support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Mock nodejs streams.
 - Create a
   [writable stream](https://nodejs.org/api/stream.html#stream_writable_streams)
   that puts its data at your disposal.
+- Create a
+  [duplex stream](https://nodejs.org/api/stream.html#stream_duplex_and_transform_streams)
+  that combines a readable and writable stream together.
 - Can operate both in
   [object](https://nodejs.org/api/stream.html#stream_object_mode) and normal
   ( [Buffer](https://nodejs.org/api/buffer.html#buffer_buf_length) ) mode.
@@ -49,7 +52,7 @@ export default class Rounder extends Transform {
 Now you need / want to test it.
 
 ```javascript
-import {ReadableMock, WritableMock } from 'stream-mock';
+import {ReadableMock, WritableMock, DuplexMock } from 'stream-mock';
 import chai from 'chai';
 
 import Rounder from 'the/seven/bloody/hells';
@@ -69,6 +72,24 @@ describe('Test me if you can', (done) => {
         writer.on('finish', ()=>{
             writer.data.should.deep.equal(input.map(Math.round));
         })
+    });
+
+    it('mocks a duplex stream', (done) = {
+        // Given
+        const stream = new DuplexMock({
+          readableObjectMode: true,
+          writableObjectMode: true
+        });
+
+        stream.on('data', ({ input }) => {
+          console.log('Got input', input);
+        })
+
+        stream.write({ input: 'a'})
+        stream.write({ input: 'b'})
+        stream.write({ input: 'c'})
+
+        stream.end()
     });
 });
 ```

--- a/src/main/duplex-mock.js
+++ b/src/main/duplex-mock.js
@@ -1,0 +1,96 @@
+/**
+ * @module duplex-mock
+ * @requires stream.Duplex
+ */
+import { Duplex } from 'stream';
+
+class DuplexMock extends Duplex {
+  constructor(options) {
+    super(options);
+
+    /**
+     * Contains data written through this stream. If this stream is operating in object mode, it will be an Array of object, otherwise it will be a Buffer.
+     * @public
+     * @member {(Array.object|Buffer)}
+     */
+    this.data = [];
+  }
+
+  /**
+   * @private
+   * @see {@link https://nodejs.org/api/stream.html#stream_readable_read_size_1 Nodejs documentation}
+   */
+  _read() {
+    if (this.data.length === 0) {
+      this.push(null);
+    } else if (this._readableState.objectMode) {
+      this.push(this.data.shift());
+    } else {
+      const buf = Buffer.from(this.data.shift().toString(), this._readableState.encoding);
+      this.push(buf);
+    }
+  }
+
+  /**
+   * Write chunk into data.
+   * @see {@link https://nodejs.org/api/stream.html#stream_writable_write_chunk_encoding_callback_1 Nodejs documentation}
+   * @private
+   * @param {(Buffer|string|*)} chunk The chunk to be written. Will always be a buffer unless the decodeStrings option was set to false or the stream is operating in object mode.
+   * @param {string} encoding  If the chunk is a string, then encoding is the character encoding of that string. If chunk is a Buffer, or if the stream is operating in object mode, encoding may be ignored.
+   * @param {function} callback Call this function (optionally with an error argument) when processing is complete for the supplied chunk.
+   */
+  _write(chunk, encoding, callback) {
+    this.data.push(chunk);
+    callback();
+  }
+
+  /**
+   * Write a bunch of chunks into data.
+   * @see {@link https://nodejs.org/api/stream.html#stream_writable_writev_chunks_callback Nodejs documentation}
+   * @private
+   * @param {Array} chunks The chunks to be written. Each chunk has following format: { chunk: ..., encoding: ... }.
+   * @param {function} callback A callback function (optionally with an error argument) to be invoked when processing is complete for the supplied chunks.
+   */
+  _writev(chunks, callback) {
+    const datas = chunks.map(c => c.chunk);
+    this.data = this.data.concat(datas);
+    callback();
+  }
+
+  /**
+   * If the stream is not in object mode, WritableMock.data will be transformed into a Buffer.
+   * @see {@link https://nodejs.org/api/stream.html#stream_writable_final_callback Nodejs documentation}
+   * @private
+   * @param {function} callback callback function
+   */
+  _final(callback) {
+    if (!this._writableState.objectMode) {
+      const length = this.data.reduce((acc, curr) => {
+        acc += curr.length;
+        return acc;
+      }, 0);
+      const buf = Buffer.alloc(length);
+      let offset = 0;
+      for (const d of this.data) {
+        d.copy(buf, offset);
+        offset += d.length;
+      }
+      this.data = buf;
+    }
+    callback();
+  }
+
+  /**
+   * If in object mode return flatten data. Useful for readable that returns arrays (hello ioredis).
+   * @returns {(Array.object|Buffer)} The flatten data if object mode, otherwise === data
+   */
+  get flatData() {
+    if (!this._writableState.objectMode) {
+      // Buffer mode, alreday flat
+      return this.data;
+    }
+    return [].concat(...this.data);
+  }
+}
+
+export default DuplexMock;

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,10 +1,13 @@
 import readable from './readable-mock';
 import writable from './writable-mock';
+import duplex from './duplex-mock';
 
 export const ReadableMock = readable;
 export const WritableMock = writable;
+export const DuplexMock = duplex;
 
 export default {
   ReadableMock: readable,
-  WritableMock: writable
+  WritableMock: writable,
+  DuplexMock: duplex
 };

--- a/src/test/duplex-mock.test.js
+++ b/src/test/duplex-mock.test.js
@@ -1,0 +1,157 @@
+/* eslint-env mocha */
+/* eslint-disable no-unused-expressions */
+import chai from 'chai';
+import sinon from 'sinon';
+
+import DuplexMock from '../main/duplex-mock';
+import ReadableMock from '../main/readable-mock';
+
+function assertDataMatch(objectMode, actual, expected) {
+  if (objectMode) {
+    actual.should.equal(expected);
+  } else {
+    actual.equals(Buffer.from(expected.toString())).should.be.true;
+  }
+}
+
+describe('DuplexMock', () => {
+  chai.should();
+
+  it('should create a new duplex instance', () => {
+    const stream = new DuplexMock();
+
+    stream.should.be.an.instanceOf(DuplexMock);
+  });
+
+  describe('Object mode', () => {
+    it('should produce data from an object', done => {
+      const source = {
+        a: 'a',
+        b: 'b',
+        c: 123
+      };
+
+      const stream = new DuplexMock({
+        readableObjectMode: true,
+        writableObjectMode: true
+      });
+
+      stream.on('data', data => assertDataMatch(true, data, source));
+      stream.write(source);
+      stream.on('end', done);
+    });
+
+    it('should produce data from an array', done => {
+      const source = [1, 2, 3];
+
+      const stream = new DuplexMock({
+        readableObjectMode: true,
+        writableObjectMode: true
+      });
+
+      stream.on('data', data => assertDataMatch(true, data, source));
+      stream.write(source);
+      stream.on('end', done);
+    });
+  });
+
+  describe('Normal (Buffer) mode', () => {
+    let stream;
+
+    beforeEach(() => {
+      stream = new DuplexMock();
+    });
+
+    afterEach(() => {
+      stream.end();
+      stream.destroy();
+    });
+
+    it('should produce data from a buffer', done => {
+      const source = Buffer.from('abcd');
+
+      stream.on('data', data => assertDataMatch(false, data, source));
+      stream.write(source);
+      stream.on('end', done);
+    });
+
+    it('should produce data from string source', done => {
+      const source = '12345';
+
+      stream.on('data', data => assertDataMatch(false, data, source));
+      stream.write(source);
+      stream.on('end', done);
+    });
+
+    it('should write buffer', done => {
+      // Given
+      const cb = sinon.spy();
+      const data = 'I\'m a proud string';
+
+      stream.on('finish', () => {
+        const actual = stream.data;
+        cb.called.should.be.true;
+        actual.should.be.an.instanceof(Buffer);
+        actual.toString().should.equal(data);
+        done();
+      });
+
+      stream.write(Buffer.from(data), cb);
+      stream.end();
+    });
+
+    it('should write and read multiple times', done => {
+      // Given
+      const data = ['a', 'b', 'c'];
+      const actualData = [];
+
+      stream.on('data', d => {
+        actualData.push(d.toString());
+      });
+
+      stream.on('finish', () => {
+        data.join('').should.equal(actualData.join(''));
+        done();
+      });
+
+      data.forEach(d => {
+        stream.write(Buffer.from(d));
+      });
+
+      stream.end();
+    });
+
+    it('should get the same result either flat or not', done => {
+      // Given
+      const cb = sinon.spy();
+      const data = 'I\'m a proud string';
+
+      stream.on('finish', () => {
+        const actual = stream.data;
+        cb.called.should.be.true;
+        actual.should.be.an.instanceof(Buffer);
+        actual.toString().should.equal(data);
+        stream.flatData.toString().should.equal(data);
+        done();
+      });
+
+      stream.write(Buffer.from(data), cb);
+      stream.end();
+    });
+
+    it('should pipe with reader', done => {
+      // Given
+      const data = 'I\'m a proud string';
+      const reader = new ReadableMock(data);
+      // When
+      reader.pipe(stream);
+      // Then
+      stream.on('finish', () => {
+        const actual = stream.data;
+        actual.should.be.an.instanceof(Buffer);
+        actual.toString().should.equal(data);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Thanks for your stream mocking library!

I needed a way to mock GRPC streams (which can be duplexes at times), and wrote this to help myself out.

I combined a bit of the logic from your read/write streams and tests to make it work.